### PR TITLE
Store session data in a cookie

### DIFF
--- a/app/session-stores/application.js
+++ b/app/session-stores/application.js
@@ -1,0 +1,5 @@
+import CookieStore from 'ember-simple-auth/session-stores/cookie';
+
+export default CookieStore.extend({
+  cookieName: 'ilios-lti-dashboard-session'
+});


### PR DESCRIPTION
Without the ember simple auth stores the data in persistent local
storage.