### PR TITLE
rm greenkeeper badge.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # LTI Dashboard
 
-[![Greenkeeper badge](https://badges.greenkeeper.io/ilios/lti-dashboard.svg)](https://greenkeeper.io/)
-
 Learning Tools Interoperability (LTI) application for the Ilios dashboard.
 
 ## Prerequisites


### PR DESCRIPTION
we've replaced Greenkeeper with Dependabot. this removes the Greenkeeper badge from the README.