### PR TITLE
Make login error message generic

### DIFF
--- a/app/templates/login-error.hbs
+++ b/app/templates/login-error.hbs
@@ -1,5 +1,4 @@
 <h1>Unable to authenticate</h1>
 <p>
-  There was an error logging you in, please report this to
-  <a href="mailto:support@iliosproject.org">support@iliosproject.org</a>.
+  There was an error logging you in, please report this to your support desk.
 </p>


### PR DESCRIPTION
Login issues should be reported to the school support desk, since we
don't know why a user would encounter issues at this point we can't be
sure we know which school they are coming from and need to send them a
generic support message.