### PR TITLE
Avoid double redirect

### DIFF
--- a/app/routes/login.js
+++ b/app/routes/login.js
@@ -27,8 +27,6 @@ export default Route.extend({
     this.session.authenticate(authenticator, { jwt });
     this.session.set('data.apiHost', apiHost);
     this.session.set('data.apiNameSpace', apiNameSpace);
-
-    this.transitionTo('index');
   },
   async getNewToken(ltiToken, apiHost) {
     const apiHostWithNoTrailingSlash = apiHost.replace(/\/+$/, "");


### PR DESCRIPTION
Ember simple auth already does this when the user is authenticated so we
don't need to do it here as well.