### PR TITLE
Send unauthenticated users to the error route

### DIFF
--- a/app/routes/index.js
+++ b/app/routes/index.js
@@ -5,6 +5,7 @@ import AuthenticatedRouteMixin from 'ember-simple-auth/mixins/authenticated-rout
 import { hash } from 'rsvp';
 
 export default class DashboardRoute extends Route.extend(AuthenticatedRouteMixin) {
+  authenticationRoute = 'login-error';
   @service store;
   @service currentUser;
 


### PR DESCRIPTION
Every user of the LTI needs to come with a token, there isn't any other
way to login so we don't need our ember-simple-auth setup to redirect
users back to the login route.