### PR TITLE
Replace page-title helper with a noop

### DIFF
--- a/app/helpers/page-title.js
+++ b/app/helpers/page-title.js
@@ -1,0 +1,9 @@
+import { helper } from '@ember/component/helper';
+
+/*
+ * This is a noop helper because the LTI shouldn't mess with the page title, but
+ * common includes {{page-title}} references.
+ */
+export default helper(function pageTitle() {
+  return '';
+});

--- a/tests/integration/helpers/page-title-test.js
+++ b/tests/integration/helpers/page-title-test.js
@@ -1,0 +1,13 @@
+import { module, test } from 'qunit';
+import { setupRenderingTest } from 'ember-qunit';
+import { render } from '@ember/test-helpers';
+import { hbs } from 'ember-cli-htmlbars';
+
+module('Integration | Helper | page-title', function(hooks) {
+  setupRenderingTest(hooks);
+
+  test('page title does nothing', async function(assert) {
+    await render(hbs`{{page-title "Jayden Rules!"}}`);
+    assert.dom().hasText("");
+  });
+});


### PR DESCRIPTION
In the latest version of ember-page-title the title attribute is sought
and modified at the document level, the LTI has no business attempting
to modify the document title so the helper is replaced with one that
does nothing. This ensures that invocations from common still work.