### PR TITLE
Fix routing

### DIFF
--- a/config/environment.js
+++ b/config/environment.js
@@ -5,7 +5,7 @@ module.exports = function (environment) {
     modulePrefix: 'lti-app',
     environment,
     rootURL: '/',
-    locationType: 'none',
+    locationType: 'history',
     'ember-simple-auth': {
       authorizer: 'authorizer:token',
       authenticationRoute: 'login-error',


### PR DESCRIPTION
I thought we needed "none" for our location type because we don't use the URL in the LTI display, however without this set to "history" we can't actually authenticate.