### PR TITLE
Remove a second loader

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -15,14 +15,6 @@
   </head>
   <body>
     {{content-for "body"}}
-    <div class="ember-load-indicator pulse-loader">
-      <svg xmlns="http://www.w3.org/2000/svg" width="670" height="236" viewBox="0 0 670 236">
-        <path class="path" stroke="#ca6728" stroke-width="4" stroke-linejoin="round" stroke-linecap="round" stroke-miterlimit="10" stroke-dasharray="391 300" stroke-dashoffset="0" fill="none" d="M0,80.9h20.6c0.5,0,1.4-0.2,1.8-0.5L38,70.1
-      	c0.5-0.3,1.2-0.3,1.6,0l12.7,9.4c0.4,0.3,1.3,0.6,1.8,0.6l13.3,0c0.6,0,1.2,0.4,1.5,0.9l6.2,11.3c0.3,0.5,0.5,0.4,0.5-0.1l4.4-90.8
-      	c0-0.5,0.1-0.5,0.1,0l6.9,102.1c0,0.5,0.2,0.6,0.4,0l7-22.4c0.2-0.5,0.7-1,1.3-1l16.1,0c0.5,0,1.3-0.3,1.8-0.7L129,66.4
-      	c0.4-0.4,1.1-0.3,1.5,0l13.3,13.1c0.4,0.4,1.2,0.7,1.7,0.7l20.1,0,"/>
-      </svg>
-    </div>
 
     <script src="{{rootURL}}assets/vendor.js"></script>
     <script src="{{rootURL}}assets/lti-app.js"></script>


### PR DESCRIPTION
Turns out we had double loaders here, the old pulse loader was still present in index.html and was no longer getting removed when we dropped the ember-load library.