### PR TITLE
adds overwrite for events route template.

### DIFF
--- a/app/templates/events.hbs
+++ b/app/templates/events.hbs
@@ -1,0 +1,2 @@
+<BackLink />
+<SingleEvent @event={{this.model}} />


### PR DESCRIPTION
this adds the "back to dashboard" link, which is about to be removed from the default template.
we only need it here b/c the LTI is expected to be delivered through an iframe, so we need this extra piece of navigation.


refs https://github.com/ilios/ilios/issues/4774
refs https://github.com/ilios/common/pull/3457