### PR TITLE
bring back our templating linting rules.

### DIFF
--- a/.template-lintrc.js
+++ b/.template-lintrc.js
@@ -1,5 +1,6 @@
 'use strict';
 
 module.exports = {
-  extends: 'recommended',
+  plugins: ['@ilios/ember-template-lint-plugin'],
+  extends: 'ilios:recommended',
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@ember/test-helpers": "^2.9.3",
         "@glimmer/component": "^1.1.2",
         "@glimmer/tracking": "^1.1.2",
+        "@ilios/ember-template-lint-plugin": "^3.0.0",
         "broccoli-asset-rev": "^3.0.0",
         "broccoli-file-creator": "^2.1.1",
         "broccoli-merge-trees": "^4.2.0",
@@ -3645,6 +3646,12 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+      "dev": true
+    },
+    "node_modules/@ilios/ember-template-lint-plugin": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@ilios/ember-template-lint-plugin/-/ember-template-lint-plugin-3.0.0.tgz",
+      "integrity": "sha512-1uCmP9E97H4DeBLzLUhGUW2Wew8y9MMmJyU4Hfs3TDgnFE2woL8DkUa2EZWs1tja5atcbYyUfnubaWkOnNSlsg==",
       "dev": true
     },
     "node_modules/@jridgewell/gen-mapping": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@ember/test-helpers": "^2.9.3",
     "@glimmer/component": "^1.1.2",
     "@glimmer/tracking": "^1.1.2",
+    "@ilios/ember-template-lint-plugin": "^3.0.0",
     "broccoli-asset-rev": "^3.0.0",
     "broccoli-file-creator": "^2.1.1",
     "broccoli-merge-trees": "^4.2.0",

--- a/tests/integration/helpers/page-title-test.js
+++ b/tests/integration/helpers/page-title-test.js
@@ -7,7 +7,8 @@ module('Integration | Helper | page-title', function (hooks) {
   setupRenderingTest(hooks);
 
   test('page title does nothing', async function (assert) {
-    await render(hbs`{{page-title 'Jayden Rules!'}}`);
+    this.set('title', 'Jayden Rules!');
+    await render(hbs`{{page-title this.title}}`);
     assert.dom().hasText('');
   });
 });


### PR DESCRIPTION
these got yanked from the project during the upgrade to Ember 4, not sure why but seems like an accident. 

see https://github.com/ilios/lti-dashboard/pull/1268/files#diff-7b37a61e2d7c941d9a45ff46e607d4a779f8484b534e5593f1292ca62edc79dc
